### PR TITLE
Make `main` breakpoint temporary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "device": "STM32L476VG",
             "preLaunchTask": "build",
             "postLaunchCommands": [
-                "-break-insert main"
+                "-break-insert -t main"
             ],
             "configFiles": [
                 "interface/stlink.cfg",
@@ -34,7 +34,7 @@
             "preLaunchTask": "build",
             "serverpath": "${env:HOME}/.comp2300/discoserver",
             "postLaunchCommands": [
-                "-break-insert main"
+                "-break-insert -t main"
             ]
         }
     ]


### PR DESCRIPTION
This breakpoint does not appear in the UI, so it is confusing when the code stops here multiple times (e.g., when `main` is a loop like in this project). Adding and removing a UI breakpoint does not remove the actual breakpoint. This change makes it a temporary breakpoint, which is removed when first visited. This also allows users to place one more breakpoint they otherwise couldn't use (limit is ~6 or so).