### PR TITLE
Print memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRCS := $(shell find src lib -name '*.c' -or -name '*.S')
 OBJS := $(addsuffix .o,$(basename $(SRCS)))
 
 CFLAGS ?=-nostdlib -nostartfiles -mcpu=cortex-m4 -mthumb -Wall -Werror -g
-LDFLAGS ?=-nostdlib -nostartfiles -T lib/link.ld
+LDFLAGS ?=-nostdlib -nostartfiles -T lib/link.ld --print-memory-usage
 
 TARGET ?= program.elf
 


### PR DESCRIPTION
Tells the linker to print memory usage. This is nice to get a feel for how much memory your code is taking up. Platformio did a similar thing (though a bit fancier).

Using `arm-none-eabli-size` is an alternative, but that gives a 'wrong' size (as it doesn't include .data needing to be stored in Flash on startup). The linker output also tells you the percent used.

For comparison, see the following
```
/home/benjamin/.comp2300/arm-none-eabi/bin/arm-none-eabi-ld -nostdlib -nostartfiles -T lib/link.ld --print-memory-usage src/main.o lib/startup.o -o program.elf
Memory region         Used Size  Region Size  %age Used
             RAM:           4 B        96 KB      0.00%
            RAM2:          0 GB        32 KB      0.00%
           FLASH:         464 B         1 MB      0.04%
/home/benjamin/.comp2300/arm-none-eabi/bin/arm-none-eabi-size program.elf
   text    data     bss     dec     hex filename
    460       4       0     464     1d0 program.elf
```

The RAM2 region is that extra pocket of RAM we don't really talk about, but I've defined in the linker script I'm using.